### PR TITLE
Add road center penalty

### DIFF
--- a/classes/Car.js
+++ b/classes/Car.js
@@ -12,8 +12,7 @@ export class Car {
         this.canvasWidth = canvasWidth;
 
         // Penalty multiplier applied when the car strays from the road center
-        // Randomized on creation but preserved when cloning
-        this.centerPenaltyMultiplier = 0.85; // Math.random() * 0.5 + 0.5;
+        this.centerPenaltyMultiplier = 0.8; // Math.random() * 0.5 + 0.5;
 
         // Current angle of the car, affects how quickly the car shifts left or right
         this.angle = 0;

--- a/classes/Car.js
+++ b/classes/Car.js
@@ -11,6 +11,10 @@ export class Car {
 
         this.canvasWidth = canvasWidth;
 
+        // Penalty multiplier applied when the car strays from the road center
+        // Randomized on creation but preserved when cloning
+        this.centerPenaltyMultiplier = Math.random() * 0.5 + 0.5;
+
         // Current angle of the car, affects how quickly the car shifts left or right
         this.angle = 0;
         // Maximum angle change per update
@@ -82,8 +86,14 @@ export class Car {
         this.angle = Math.max(-Math.PI/2, Math.min(Math.PI/2, newAngle));
         this.x += Math.sin(this.angle) * this.speed;
 
-        // 6. Accumulate fitness (e.g., distance traveled)
+        // 6. Accumulate fitness (distance traveled) and apply penalty for
+        // drifting away from the road center
         this.fitness += this.speed;
+
+        const centerX = this.canvasWidth / 2;
+        const distanceFromCenter = Math.abs(this.x - centerX);
+        const normalized = distanceFromCenter / centerX; // 0 at center, 1 at edge
+        this.fitness -= normalized * this.centerPenaltyMultiplier * this.speed;
     }
   
     /**
@@ -134,6 +144,7 @@ export class Car {
             this.canvasWidth,
             this.speed
         );
+        clone.centerPenaltyMultiplier = this.centerPenaltyMultiplier;
         clone.alive = true;
         //console.log("Cloning brain");
         clone.brain = this.brain.clone();

--- a/classes/Car.js
+++ b/classes/Car.js
@@ -13,7 +13,7 @@ export class Car {
 
         // Penalty multiplier applied when the car strays from the road center
         // Randomized on creation but preserved when cloning
-        this.centerPenaltyMultiplier = Math.random() * 0.5 + 0.5;
+        this.centerPenaltyMultiplier = 100; // Math.random() * 0.5 + 0.5;
 
         // Current angle of the car, affects how quickly the car shifts left or right
         this.angle = 0;
@@ -144,7 +144,7 @@ export class Car {
             this.canvasWidth,
             this.speed
         );
-        clone.centerPenaltyMultiplier = this.centerPenaltyMultiplier;
+        // clone.centerPenaltyMultiplier = this.centerPenaltyMultiplier;
         clone.alive = true;
         //console.log("Cloning brain");
         clone.brain = this.brain.clone();

--- a/classes/Car.js
+++ b/classes/Car.js
@@ -13,7 +13,7 @@ export class Car {
 
         // Penalty multiplier applied when the car strays from the road center
         // Randomized on creation but preserved when cloning
-        this.centerPenaltyMultiplier = 100; // Math.random() * 0.5 + 0.5;
+        this.centerPenaltyMultiplier = 0.85; // Math.random() * 0.5 + 0.5;
 
         // Current angle of the car, affects how quickly the car shifts left or right
         this.angle = 0;
@@ -111,6 +111,32 @@ export class Car {
         for (const ray of this.rays) {
             ray.draw(ctx);
         }
+
+        // Draw fitness score above car (in world space, before transformations)
+        ctx.save();
+        ctx.font = "12px monospace";
+        const fitnessText = Math.floor(this.fitness).toString();
+        const textWidth = ctx.measureText(fitnessText).width;
+        
+        // Draw background rectangle for better readability
+        ctx.fillStyle = "rgba(0, 0, 0, 0.7)";
+        ctx.fillRect(
+            this.x - textWidth/2 - 2,  // x
+            this.y - this.height/2 - 20,  // y (above car)
+            textWidth + 4,  // width
+            16  // height
+        );
+        
+        // Draw fitness text
+        ctx.fillStyle = "white";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText(
+            fitnessText,
+            this.x,
+            this.y - this.height/2 - 12
+        );
+        ctx.restore();
 
         // Save the current canvas state before transformations
         ctx.save();

--- a/classes/NeuralNetwork.js
+++ b/classes/NeuralNetwork.js
@@ -91,5 +91,29 @@ export class NeuralNetwork {
         );
         this.biases = this.biases.map(layer => layer.map(mutateValue));
     }
+
+    /**
+     * Prints the neural network structure to the console in a readable format.
+     */
+    printNetwork() {
+        console.log('\n=== Neural Network Structure ===');
+        console.log(`Input Layer: ${this.inputSize} neurons`);
+        this.hiddenSizes.forEach((size, i) => {
+            console.log(`Hidden Layer ${i + 1}: ${size} neurons`);
+        });
+        console.log(`Output Layer: ${this.outputSize} neurons\n`);
+
+        console.log('=== Weights and Biases ===');
+        for (let i = 0; i < this.weights.length; i++) {
+            console.log(`\nLayer ${i + 1} (${this.layerSizes[i]} → ${this.layerSizes[i + 1]}):`);
+            console.log('Weights:');
+            this.weights[i].forEach((row, j) => {
+                console.log(`  Neuron ${j + 1}: ${row.map(w => w.toFixed(3)).join(', ')}`);
+            });
+            console.log('Biases:');
+            console.log(`  ${this.biases[i].map(b => b.toFixed(3)).join(', ')}`);
+        }
+        console.log('\n===========================\n');
+    }
 }
   

--- a/helpers/SimulationManager.js
+++ b/helpers/SimulationManager.js
@@ -122,6 +122,12 @@ export class SimulationManager {
     evolveNextGeneration() {
         this.cars.sort((a, b) => b.fitness - a.fitness); // sort by fitness
         const elites = this.cars.slice(0, this.eliteCount); // get best cars
+        
+        // Print the best car's neural network
+        console.log(`\n=== Best Car from Generation ${this.generation} ===`);
+        console.log(`Fitness: ${Math.floor(elites[0].fitness)}`);
+        elites[0].brain.printNetwork();
+        
         const newCars = [];
 
         // Add unmutated elites

--- a/main.js
+++ b/main.js
@@ -18,7 +18,7 @@ initRoadLines(canvas.height);
 // Define constants
 const SPEED = 1;
 const NUM_OBSTACLES = 8;
-const POPULATION_SIZE = 30;
+const POPULATION_SIZE = 60;
 const PARENT_COUNT = 10;
 const MUTATION_RATE = 0.1;
 

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ initRoadLines(canvas.height);
 
 // Define constants
 const SPEED = 1;
-const NUM_OBSTACLES = 6;
+const NUM_OBSTACLES = 8;
 const POPULATION_SIZE = 30;
 const PARENT_COUNT = 10;
 const MUTATION_RATE = 0.1;


### PR DESCRIPTION
## Summary
- keep a random `centerPenaltyMultiplier` as an internal car property
- preserve multiplier when cloning cars
- remove extra constructor arguments from `SimulationManager`
- penalize cars for drifting away from center

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b93304d488332a8a45c07b3199838