### PR TITLE
Fix distance overlay

### DIFF
--- a/classes/Car.js
+++ b/classes/Car.js
@@ -23,7 +23,7 @@ export class Car {
         this.speed = speed;
         // Whether the car has hit an obstacle or not
         this.alive = true;
-        // How far the car has traveled
+        // Fitness value used for evolution (includes penalties)
         this.fitness = 0;
 
         // Initialize rays
@@ -86,7 +86,7 @@ export class Car {
         this.angle = Math.max(-Math.PI/2, Math.min(Math.PI/2, newAngle));
         this.x += Math.sin(this.angle) * this.speed;
 
-        // 6. Accumulate fitness (distance traveled) and apply penalty for
+        // 6. Update fitness (distance traveled) and apply penalty for
         // drifting away from the road center
         this.fitness += this.speed;
 

--- a/helpers/SimulationManager.js
+++ b/helpers/SimulationManager.js
@@ -16,6 +16,7 @@ export class SimulationManager {
         this.cars = [];
         this.deadCars = [];
         this.maxFitness = 0;  // Track best fitness in current generation
+        this.distanceTraveled = 0; // Total distance traveled this generation
         this.isEvolving = false; // Flag for generation transition delay
 
         this.spawnInitialPopulation();
@@ -47,6 +48,11 @@ export class SimulationManager {
                 car.update(this.obstacleManager.getObstacles());
                 this.maxFitness = Math.max(this.maxFitness, car.fitness);
             }
+        }
+
+        // Increment overall distance if at least one car is alive
+        if (this.cars.some(car => car.alive)) {
+            this.distanceTraveled += this.speed;
         }
 
         // Check if all cars are dead
@@ -88,7 +94,7 @@ export class SimulationManager {
             
             // Draw message
             const message = `Generation ${this.generation} Complete`;
-            const subMessage = `Best Distance: ${Math.floor(this.maxFitness)}`;
+            const subMessage = `Best Distance: ${Math.floor(this.distanceTraveled)}`;
             ctx.fillText(message, this.canvas.width / 2, this.canvas.height / 2 - 20);
             ctx.fillText(subMessage, this.canvas.width / 2, this.canvas.height / 2 + 20);
             
@@ -109,8 +115,8 @@ export class SimulationManager {
         ctx.textAlign = "left";
         ctx.fillText(`Generation: ${this.generation}`, 10, 30);
         
-        // Draw current max fitness
-        ctx.fillText(`Distance: ${Math.floor(this.maxFitness)}`, 10, 55);
+        // Draw current distance traveled
+        ctx.fillText(`Distance: ${Math.floor(this.distanceTraveled)}`, 10, 55);
         
         // Draw alive cars count
         const aliveCount = this.cars.filter(car => car.alive).length;
@@ -126,6 +132,7 @@ export class SimulationManager {
         // Print the best car's neural network
         console.log(`\n=== Best Car from Generation ${this.generation} ===`);
         console.log(`Fitness: ${Math.floor(elites[0].fitness)}`);
+        console.log(`Distance: ${Math.floor(this.distanceTraveled)}`);
         elites[0].brain.printNetwork();
         
         const newCars = [];
@@ -161,6 +168,7 @@ export class SimulationManager {
         this.cars = newCars;
         this.deadCars = [];
         this.maxFitness = 0;
+        this.distanceTraveled = 0;
         this.generation++;
 
         


### PR DESCRIPTION
## Summary
- separate raw distance from fitness score
- display max distance reached in overlay and generation summary
- log both fitness and distance when evolving to next generation

## Testing
- `node --check main.js`
- `node --check classes/Car.js`
- `node --check helpers/SimulationManager.js`


------
https://chatgpt.com/codex/tasks/task_e_684c82f8d5bc8332bd8684231920a828