### PR TITLE
Allow obstacles to spawn against road edges

### DIFF
--- a/helpers/ObstacleManager.js
+++ b/helpers/ObstacleManager.js
@@ -27,8 +27,14 @@ export class ObstacleManager {
     }
 
     getRandomX() {
-        const margin = 40;
-        return margin + Math.random() * (this.canvas.width - 2 * margin);
+        // Allow obstacles to spawn partially outside the road bounds so that
+        // "side hugging" cars cannot exploit a gap next to the walls. An
+        // obstacle's center can be anywhere from -width/2 to
+        // canvas.width + width/2 which means it may overlap the wall by up to
+        // half of its width but will never be completely outside the canvas.
+        const minX = -this.width / 2;
+        const maxX = this.canvas.width + this.width / 2;
+        return minX + Math.random() * (maxX - minX);
     }
 
     updateAll(cars) {


### PR DESCRIPTION
## Summary
- update obstacle placement logic so obstacles can overlap the sides of the road by up to half their width

## Testing
- `node --check helpers/ObstacleManager.js`


------
https://chatgpt.com/codex/tasks/task_e_684dbae74abc8332950fbf13ab5107c1