### PR TITLE
Implement arena physics mode

### DIFF
--- a/classes/Obstacle.js
+++ b/classes/Obstacle.js
@@ -1,14 +1,16 @@
 export class Obstacle {
-    constructor(x, y, width, height, speed) {
+    constructor(x, y, width, height, vx = 0, vy = 0) {
         this.x = x;
         this.y = y;
         this.width = width;
         this.height = height;
-        this.speed = speed; // downward speed
+        this.vx = vx;
+        this.vy = vy;
     }
-  
+
     update() {
-        this.y += this.speed;
+        this.x += this.vx;
+        this.y += this.vy;
     }
   
     draw(ctx) {

--- a/helpers/ObstacleManager.js
+++ b/helpers/ObstacleManager.js
@@ -1,10 +1,9 @@
 import { Obstacle } from "../classes/Obstacle.js";
 
 export class ObstacleManager {
-    constructor(canvas, obstacleCount = 5, speed) {
+    constructor(canvas, obstacleCount = 5) {
         this.canvas = canvas;
         this.count = obstacleCount;
-        this.speed = speed;
         this.width = 40;
         this.height = 15;
         this.obstacles = [];
@@ -14,37 +13,24 @@ export class ObstacleManager {
 
     initializeObstacles() {
         this.obstacles = [];
-        // Add moving obstacles
+
         for (let i = 0; i < this.count; i++) {
-            const x = this.getRandomX();
-            const y = -i * 200;  // Space them out vertically above the screen
-            this.obstacles.push(new Obstacle(x, y, this.width, this.height, this.speed));
+            const x = Math.random() * (this.canvas.width - this.width) + this.width / 2;
+            const y = Math.random() * (this.canvas.height - this.height) + this.height / 2;
+            this.obstacles.push(new Obstacle(x, y, this.width, this.height));
         }
 
-        // Manually add sides of the road as obstacles
-        this.obstacles.push(new Obstacle(0, this.canvas.height / 2, 10, this.canvas.height, 0)); // left wall
-        this.obstacles.push(new Obstacle(this.canvas.width, this.canvas.height / 2, 10, this.canvas.height, 0)); // right wall
+        // Arena walls
+        this.obstacles.push(new Obstacle(this.canvas.width / 2, 5, this.canvas.width, 10)); // top
+        this.obstacles.push(new Obstacle(this.canvas.width / 2, this.canvas.height - 5, this.canvas.width, 10)); // bottom
+        this.obstacles.push(new Obstacle(5, this.canvas.height / 2, 10, this.canvas.height)); // left
+        this.obstacles.push(new Obstacle(this.canvas.width - 5, this.canvas.height / 2, 10, this.canvas.height)); // right
     }
 
-    getRandomX() {
-        // Allow obstacles to spawn partially outside the road bounds so that
-        // "side hugging" cars cannot exploit a gap next to the walls. An
-        // obstacle's center can be anywhere from -width/2 to
-        // canvas.width + width/2 which means it may overlap the wall by up to
-        // half of its width but will never be completely outside the canvas.
-        const minX = -this.width / 2;
-        const maxX = this.canvas.width + this.width / 2;
-        return minX + Math.random() * (maxX - minX);
-    }
 
     updateAll(cars) {
         for (const obs of this.obstacles) {
             obs.update();
-
-            if (obs.y - obs.height / 2 > this.canvas.height) {
-                obs.y = -this.height;
-                obs.x = this.getRandomX();
-            }
 
             for (const car of cars) {
                 if (car.alive && obs.collidesWith(car)) {
@@ -64,20 +50,8 @@ export class ObstacleManager {
         return this.obstacles;
     }
 
-    // Reset all moving obstacles to starting positions
+    // Reset obstacles for new generation
     reset() {
-        // Keep the last two obstacles (walls) and reset the moving ones
-        const walls = this.obstacles.slice(-2);
-        this.obstacles = [];
-        
-        // Reinitialize moving obstacles
-        for (let i = 0; i < this.count; i++) {
-            const x = this.getRandomX();
-            const y = -i * 200;  // Space them out vertically above the screen
-            this.obstacles.push(new Obstacle(x, y, this.width, this.height, this.speed));
-        }
-        
-        // Add back the walls
-        this.obstacles.push(...walls);
+        this.initializeObstacles();
     }
 }

--- a/helpers/SimulationManager.js
+++ b/helpers/SimulationManager.js
@@ -37,9 +37,11 @@ export class SimulationManager {
         for (let i = 0; i < this.populationSize; i++) {
             this.cars.push(new Car(
                 this.canvas.width / 2,  // x
+                this.canvas.height / 2, // y
                 this.CAR_WIDTH,         // width
                 this.CAR_HEIGHT,        // height
                 this.canvas.width,      // canvasWidth
+                this.canvas.height,     // canvasHeight
                 this.speed,             // speed
                 this.generation         // generation
             ));
@@ -68,7 +70,7 @@ export class SimulationManager {
 
         // Increment overall distance if at least one car is alive
         if (this.cars.some(car => car.alive)) {
-            this.distanceTraveled += this.speed;
+            this.distanceTraveled += 1;
         }
 
         // Check if all cars are dead

--- a/main.js
+++ b/main.js
@@ -1,10 +1,6 @@
 import { SimulationManager } from './helpers/SimulationManager.js';
 import { StatisticsManager } from './helpers/StatisticsManager.js';
-import {
-    initRoadLines,
-    updateRoadLines,
-    drawRoadLines,
-  } from './helpers/roadLines.js';
+
 import { ObstacleManager } from './helpers/ObstacleManager.js';
 
 // Get canvas and context
@@ -13,9 +9,6 @@ canvas.width = 600;
 canvas.height = 800;
 const ctx = canvas.getContext("2d");
 
-// Initialize road lines
-initRoadLines(canvas.height);
-
 // Define constants
 const SPEED = 1;
 const NUM_OBSTACLES = 10;
@@ -23,7 +16,7 @@ const POPULATION_SIZE = 100;
 const PARENT_COUNT = 10;
 const MUTATION_RATE = 0.2;
 
-const simManager = new SimulationManager(canvas, new ObstacleManager(canvas, NUM_OBSTACLES, SPEED), 
+const simManager = new SimulationManager(canvas, new ObstacleManager(canvas, NUM_OBSTACLES),
   POPULATION_SIZE, PARENT_COUNT, SPEED, MUTATION_RATE);
 
 // Initialize statistics manager
@@ -33,9 +26,6 @@ const statsManager = new StatisticsManager(simManager);
 function animate() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-    updateRoadLines(SPEED, canvas.height);
-    drawRoadLines(ctx, canvas.width);
-  
     simManager.update();
     simManager.draw(ctx);
   


### PR DESCRIPTION
## Summary
- adapt `Car` to update both X and Y using heading
- spawn cars at the arena center and clamp them to canvas bounds
- change `Obstacle` to support 2‑D movement
- update `ObstacleManager` for a static arena with boundary walls
- simplify `SimulationManager` distance logic
- remove road line support from `main.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859dbcac7848332a1d07968648a1ec5